### PR TITLE
Add sanity check when retrieving the cluster collection for a given detID

### DIFF
--- a/EventFilter/Phase2TrackerRawToDigi/interface/SensorHybrid.h
+++ b/EventFilter/Phase2TrackerRawToDigi/interface/SensorHybrid.h
@@ -12,11 +12,15 @@ class SensorHybrid
 {
     private:
 
-        std::vector<Phase2TrackerCluster1D*> get_clusters_on_cic(edmNew::DetSetVector<Phase2TrackerCluster1D>::const_iterator clusterIterator, const bool& cic_id, const TrackerGeometry& trackerGeometry, const int internal_id) 
+        std::vector<Phase2TrackerCluster1D*> get_clusters_on_cic(edmNew::DetSetVector<Phase2TrackerCluster1D>::const_iterator clusterIterator, const bool clusters_exist, const bool& cic_id, const TrackerGeometry& trackerGeometry, const int internal_id) 
         {
             using namespace Phase2TrackerSpecifications;
             using namespace Phase2DAQFormatSpecification;
 
+            std::vector<Phase2TrackerCluster1D*> filteredClusters;
+            if (!clusters_exist)
+              return filteredClusters;
+            
             const GeomDetUnit* sensor_unit = trackerGeometry.idToDetUnit(clusterIterator->detId());
             unsigned int cic_boundary_in_z = CIC_Z_BOUNDARY_STRIPS;
 
@@ -66,7 +70,6 @@ class SensorHybrid
                 }
             }
 
-            std::vector<Phase2TrackerCluster1D*> filteredClusters;
 
             if ( clusterIterator != edmNew::DetSetVector<Phase2TrackerCluster1D>::const_iterator{} ) 
             {
@@ -247,10 +250,12 @@ class SensorHybrid
     public:
 
         SensorHybrid(edmNew::DetSetVector<Phase2TrackerCluster1D>::const_iterator sensor_1, 
-                    edmNew::DetSetVector<Phase2TrackerCluster1D>::const_iterator sensor_2, const bool cic_id, const TrackerGeometry& trackerGeometry, const unsigned int eventId) : cic_id_(cic_id), eventId_(eventId)
+                    edmNew::DetSetVector<Phase2TrackerCluster1D>::const_iterator sensor_2, 
+                    const bool sensor_1_clusters_exist, const bool sensor_2_clusters_exist,
+                    const bool cic_id, const TrackerGeometry& trackerGeometry, const unsigned int eventId) : cic_id_(cic_id), eventId_(eventId)
         {
-            sensor_1_clusters_ = get_clusters_on_cic(sensor_1, cic_id, trackerGeometry, 1);
-            sensor_2_clusters_ = get_clusters_on_cic(sensor_2, cic_id, trackerGeometry, 2);
+            sensor_1_clusters_ = get_clusters_on_cic(sensor_1, sensor_1_clusters_exist, cic_id, trackerGeometry, 1);
+            sensor_2_clusters_ = get_clusters_on_cic(sensor_2, sensor_2_clusters_exist, cic_id, trackerGeometry, 2);
         }
 
         unsigned int    get_payload_size() 

--- a/EventFilter/Phase2TrackerRawToDigi/plugins/ClusterToRawProducer.cc
+++ b/EventFilter/Phase2TrackerRawToDigi/plugins/ClusterToRawProducer.cc
@@ -107,8 +107,20 @@ void ClusterToRawProducer::produce(edm::Event& iEvent, const edm::EventSetup& iS
                     auto link_to_det_association = cablingMap.dtcELinkIdToDetId(cms_link_id);
                     const DetId& det_id = link_to_det_association->second;
 
-                    edmNew::DetSetVector<Phase2TrackerCluster1D>::const_iterator sensor_1_cluster_collection = iEvent.get(ClusterCollectionToken_).find(det_id + 1);
-                    edmNew::DetSetVector<Phase2TrackerCluster1D>::const_iterator sensor_2_cluster_collection = iEvent.get(ClusterCollectionToken_).find(det_id + 2);
+                    edmNew::DetSetVector<Phase2TrackerCluster1D> all_clusters = iEvent.get(ClusterCollectionToken_);
+                    // In order to prevent issues when retrieving the cluster collection for a given detID, check if it exists.
+                    // (the edmNew::DetSetVector.find method returns end() if the collection for the required det_id is not there, 
+                    // which could lead to inconsistencies later on)
+                    // If the collection does not exist, add an empty collection with the same det_id in order to preserve the rest of the packing steps
+                    if (!(all_clusters.exists(det_id + 1) )){
+                      all_clusters.insert(det_id+1, 0);
+                    }
+                    if (!(all_clusters.exists(det_id + 2) )){
+                      all_clusters.insert(det_id+2, 0);
+                    }
+
+                    edmNew::DetSetVector<Phase2TrackerCluster1D>::const_iterator sensor_1_cluster_collection = all_clusters.find(det_id + 1);
+                    edmNew::DetSetVector<Phase2TrackerCluster1D>::const_iterator sensor_2_cluster_collection = all_clusters.find(det_id + 2);
 
                     // sensor_1_cic_0 and sensor_2_cic_0 form a single output daq channel.
                     SensorHybrid Hybrid_1 (sensor_1_cluster_collection, sensor_2_cluster_collection, 0, trackerGeometry, eventId_);

--- a/EventFilter/Phase2TrackerRawToDigi/plugins/ClusterToRawProducer.cc
+++ b/EventFilter/Phase2TrackerRawToDigi/plugins/ClusterToRawProducer.cc
@@ -81,6 +81,9 @@ void ClusterToRawProducer::produce(edm::Event& iEvent, const edm::EventSetup& iS
     using namespace Phase2TrackerSpecifications;
     using namespace Phase2DAQFormatSpecification;
 
+    // Retrieve collection of clusters from the event
+    edmNew::DetSetVector<Phase2TrackerCluster1D> all_clusters = iEvent.get(ClusterCollectionToken_);
+
     for (int dtc_id = MIN_DTC_ID; dtc_id < MAX_DTC_ID + 1; dtc_id++)
     {
         for (int slink_id = 0; slink_id < MAX_SLINK_ID + 1; slink_id++)
@@ -107,26 +110,20 @@ void ClusterToRawProducer::produce(edm::Event& iEvent, const edm::EventSetup& iS
                     auto link_to_det_association = cablingMap.dtcELinkIdToDetId(cms_link_id);
                     const DetId& det_id = link_to_det_association->second;
 
-                    edmNew::DetSetVector<Phase2TrackerCluster1D> all_clusters = iEvent.get(ClusterCollectionToken_);
                     // In order to prevent issues when retrieving the cluster collection for a given detID, check if it exists.
                     // (the edmNew::DetSetVector.find method returns end() if the collection for the required det_id is not there, 
                     // which could lead to inconsistencies later on)
-                    // If the collection does not exist, add an empty collection with the same det_id in order to preserve the rest of the packing steps
-                    if (!(all_clusters.exists(det_id + 1) )){
-                      all_clusters.insert(det_id+1, 0);
-                    }
-                    if (!(all_clusters.exists(det_id + 2) )){
-                      all_clusters.insert(det_id+2, 0);
-                    }
-
+                    bool const sensor_1_clusters_exist = (all_clusters.exists(det_id + 1)) ? true : false;
                     edmNew::DetSetVector<Phase2TrackerCluster1D>::const_iterator sensor_1_cluster_collection = all_clusters.find(det_id + 1);
-                    edmNew::DetSetVector<Phase2TrackerCluster1D>::const_iterator sensor_2_cluster_collection = all_clusters.find(det_id + 2);
 
+                    bool const sensor_2_clusters_exist = (all_clusters.exists(det_id + 2)) ? true : false;
+                    edmNew::DetSetVector<Phase2TrackerCluster1D>::const_iterator sensor_2_cluster_collection = all_clusters.find(det_id + 2);
+                    
                     // sensor_1_cic_0 and sensor_2_cic_0 form a single output daq channel.
-                    SensorHybrid Hybrid_1 (sensor_1_cluster_collection, sensor_2_cluster_collection, 0, trackerGeometry, eventId_);
+                    SensorHybrid Hybrid_1 (sensor_1_cluster_collection, sensor_2_cluster_collection, sensor_1_clusters_exist, sensor_2_clusters_exist, 0, trackerGeometry, eventId_);
 
                     // // sensor_1_cic_1 and sensor_2_cic_1 form a single output daq channel.
-                    SensorHybrid Hybrid_2 (sensor_1_cluster_collection, sensor_2_cluster_collection, 1, trackerGeometry, eventId_);
+                    SensorHybrid Hybrid_2 (sensor_1_cluster_collection, sensor_2_cluster_collection, sensor_1_clusters_exist, sensor_2_clusters_exist, 1, trackerGeometry, eventId_);
 
                     // sensor_2 is always isUpper == 1 for 2S.
                     // sensor_2 is always isLower == 0 for 2S.

--- a/EventFilter/Phase2TrackerRawToDigi/plugins/ClusterToRawProducer.cc
+++ b/EventFilter/Phase2TrackerRawToDigi/plugins/ClusterToRawProducer.cc
@@ -82,7 +82,7 @@ void ClusterToRawProducer::produce(edm::Event& iEvent, const edm::EventSetup& iS
     using namespace Phase2DAQFormatSpecification;
 
     // Retrieve collection of clusters from the event
-    edmNew::DetSetVector<Phase2TrackerCluster1D> all_clusters = iEvent.get(ClusterCollectionToken_);
+    edmNew::DetSetVector<Phase2TrackerCluster1D> const& all_clusters = iEvent.get(ClusterCollectionToken_);
 
     for (int dtc_id = MIN_DTC_ID; dtc_id < MAX_DTC_ID + 1; dtc_id++)
     {

--- a/EventFilter/Phase2TrackerRawToDigi/plugins/RawToClusterProducer.cc
+++ b/EventFilter/Phase2TrackerRawToDigi/plugins/RawToClusterProducer.cc
@@ -206,6 +206,10 @@ void RawToClusterProducer::produce(edm::Event& iEvent, const edm::EventSetup& iS
             unsigned int numStripClusters = (headerWord >> (N_BITS_PER_WORD - L1ID_BITS - CIC_ERROR_BITS - N_STRIP_CLUSTER_BITS)) & N_CLUSTER_MASK; // 7-bit field
             unsigned int numPixelClusters = (headerWord) & N_CLUSTER_MASK; // 7-bit field
             
+            if (is2SModule && numPixelClusters > 0)
+              edm::LogWarning("RawToClusterProducer") << "Header for channel " << iChannel << " expects non-zero (" << numPixelClusters 
+                                                      << ") pixel clusters on a 2S module" ;
+              
             // define the number of lines of the payload
             unsigned int nLines = (numStripClusters + numPixelClusters > 0) ? 
                                    int((numStripClusters * SS_CLUSTER_BITS + numPixelClusters * PX_CLUSTER_BITS)/ N_BITS_PER_WORD) + 1 : 0;

--- a/EventFilter/Phase2TrackerRawToDigi/plugins/RawToClusterProducer.cc
+++ b/EventFilter/Phase2TrackerRawToDigi/plugins/RawToClusterProducer.cc
@@ -207,8 +207,8 @@ void RawToClusterProducer::produce(edm::Event& iEvent, const edm::EventSetup& iS
             unsigned int numPixelClusters = (headerWord) & N_CLUSTER_MASK; // 7-bit field
             
             if (is2SModule && numPixelClusters > 0)
-              edm::LogWarning("RawToClusterProducer") << "Header for channel " << iChannel << " expects non-zero (" << numPixelClusters 
-                                                      << ") pixel clusters on a 2S module" ;
+              edm::LogError("RawToClusterProducer") << "Header for channel " << iChannel << " expects non-zero (" << numPixelClusters 
+                                                    << ") pixel clusters on a 2S module" ;
               
             // define the number of lines of the payload
             unsigned int nLines = (numStripClusters + numPixelClusters > 0) ? 


### PR DESCRIPTION
#### PR description:

Add sanity check when retrieving the cluster collection for a given detID using the find() method, which would return a pointer to the last element of the DetSetVector<Phase2TrackerCluster1D> if the desired detID is not present.
This was causing inconsistencies, e.g. if the last element of the DetSetVector<Phase2TrackerCluster1D> was a PS module a number of pixel clusters > 0 could have been "packed" in the payload header of a 2S module, in turn causing issues in the unpacking step.

A warning is also added in the unpacking step, which could be maybe raised to LogError, what do people think?