### PR TITLE
sensorHybrid: update sensor types before returning empty clusters 

### DIFF
--- a/EventFilter/Phase2TrackerRawToDigi/interface/SensorHybrid.h
+++ b/EventFilter/Phase2TrackerRawToDigi/interface/SensorHybrid.h
@@ -18,7 +18,7 @@ class SensorHybrid
             using namespace Phase2DAQFormatSpecification;
 
             std::vector<Phase2TrackerCluster1D*> filteredClusters;
-            const GeomDetUnit* sensor_unit = trackerGeometry.idToDetUnit(det_id);
+            const GeomDetUnit* sensor_unit = trackerGeometry.idToDetUnit(det_id+1);
             unsigned int cic_boundary_in_z = CIC_Z_BOUNDARY_STRIPS;
 
             if (sensor_unit) 
@@ -84,7 +84,6 @@ class SensorHybrid
                     }
                 }
             }
-
             return filteredClusters;
         }
 
@@ -97,7 +96,7 @@ class SensorHybrid
             uint32_t currentWord = 0;
             int bitsFilled = 0;
 
-            if (sensor_type_1 == TrackerGeometry::ModuleType::Ph2PSP && sensor_type_2 == TrackerGeometry::ModuleType::Ph2PSS)
+            if (sensor_type_1 == TrackerGeometry::ModuleType::Ph2PSP || sensor_type_2 == TrackerGeometry::ModuleType::Ph2PSS)
             {
 
                 // For PS, sensor_2 is always strip and sensor_1 is always pixel
@@ -290,7 +289,7 @@ class SensorHybrid
         }
         unsigned int  get_number_of_pixel_clusters()  
         {
-            if (sensor_type_1 == TrackerGeometry::ModuleType::Ph2PSP)
+            if (sensor_type_1 == TrackerGeometry::ModuleType::Ph2PSP || sensor_type_2 == TrackerGeometry::ModuleType::Ph2PSS)
             {
                 return sensor_1_clusters_.size();
             }

--- a/EventFilter/Phase2TrackerRawToDigi/interface/SensorHybrid.h
+++ b/EventFilter/Phase2TrackerRawToDigi/interface/SensorHybrid.h
@@ -12,21 +12,18 @@ class SensorHybrid
 {
     private:
 
-        std::vector<Phase2TrackerCluster1D*> get_clusters_on_cic(edmNew::DetSetVector<Phase2TrackerCluster1D>::const_iterator clusterIterator, const bool clusters_exist, const bool& cic_id, const TrackerGeometry& trackerGeometry, const int internal_id) 
+        std::vector<Phase2TrackerCluster1D*> get_clusters_on_cic(const DetId& det_id, edmNew::DetSetVector<Phase2TrackerCluster1D>::const_iterator clusterIterator, const bool clusters_exist, const bool& cic_id, const TrackerGeometry& trackerGeometry, const int internal_id) 
         {
             using namespace Phase2TrackerSpecifications;
             using namespace Phase2DAQFormatSpecification;
 
             std::vector<Phase2TrackerCluster1D*> filteredClusters;
-            if (!clusters_exist)
-              return filteredClusters;
-            
-            const GeomDetUnit* sensor_unit = trackerGeometry.idToDetUnit(clusterIterator->detId());
+            const GeomDetUnit* sensor_unit = trackerGeometry.idToDetUnit(det_id);
             unsigned int cic_boundary_in_z = CIC_Z_BOUNDARY_STRIPS;
 
             if (sensor_unit) 
             {
-                TrackerGeometry::ModuleType moduleType = trackerGeometry.getDetectorType(clusterIterator->detId()); 
+                TrackerGeometry::ModuleType moduleType = trackerGeometry.getDetectorType(det_id);
                 switch (moduleType)
                 {
                     case TrackerGeometry::ModuleType::Ph2PSS:
@@ -70,6 +67,8 @@ class SensorHybrid
                 }
             }
 
+            if (!clusters_exist)
+                return filteredClusters;
 
             if ( clusterIterator != edmNew::DetSetVector<Phase2TrackerCluster1D>::const_iterator{} ) 
             {
@@ -98,7 +97,7 @@ class SensorHybrid
             uint32_t currentWord = 0;
             int bitsFilled = 0;
 
-            if (sensor_type_1 == TrackerGeometry::ModuleType::Ph2PSP || sensor_type_2 == TrackerGeometry::ModuleType::Ph2PSS)
+            if (sensor_type_1 == TrackerGeometry::ModuleType::Ph2PSP && sensor_type_2 == TrackerGeometry::ModuleType::Ph2PSS)
             {
 
                 // For PS, sensor_2 is always strip and sensor_1 is always pixel
@@ -233,6 +232,8 @@ class SensorHybrid
                 {
                     payload.push_back(currentWord);
                 }
+            } else {
+                edm::LogError("SensorHybrid") << "Sensor 1 and 2 have inconsistent types";
             }
         }
 
@@ -249,13 +250,14 @@ class SensorHybrid
 
     public:
 
-        SensorHybrid(edmNew::DetSetVector<Phase2TrackerCluster1D>::const_iterator sensor_1, 
+        SensorHybrid(const DetId& det_id,
+                    edmNew::DetSetVector<Phase2TrackerCluster1D>::const_iterator sensor_1, 
                     edmNew::DetSetVector<Phase2TrackerCluster1D>::const_iterator sensor_2, 
                     const bool sensor_1_clusters_exist, const bool sensor_2_clusters_exist,
                     const bool cic_id, const TrackerGeometry& trackerGeometry, const unsigned int eventId) : cic_id_(cic_id), eventId_(eventId)
         {
-            sensor_1_clusters_ = get_clusters_on_cic(sensor_1, sensor_1_clusters_exist, cic_id, trackerGeometry, 1);
-            sensor_2_clusters_ = get_clusters_on_cic(sensor_2, sensor_2_clusters_exist, cic_id, trackerGeometry, 2);
+            sensor_1_clusters_ = get_clusters_on_cic(det_id, sensor_1, sensor_1_clusters_exist, cic_id, trackerGeometry, 1);
+            sensor_2_clusters_ = get_clusters_on_cic(det_id, sensor_2, sensor_2_clusters_exist, cic_id, trackerGeometry, 2);
         }
 
         unsigned int    get_payload_size() 
@@ -288,7 +290,7 @@ class SensorHybrid
         }
         unsigned int  get_number_of_pixel_clusters()  
         {
-            if (sensor_type_1 == TrackerGeometry::ModuleType::Ph2PSP || sensor_type_2 == TrackerGeometry::ModuleType::Ph2PSS)
+            if (sensor_type_1 == TrackerGeometry::ModuleType::Ph2PSP)
             {
                 return sensor_1_clusters_.size();
             }

--- a/EventFilter/Phase2TrackerRawToDigi/plugins/ClusterToRawProducer.cc
+++ b/EventFilter/Phase2TrackerRawToDigi/plugins/ClusterToRawProducer.cc
@@ -120,10 +120,10 @@ void ClusterToRawProducer::produce(edm::Event& iEvent, const edm::EventSetup& iS
                     edmNew::DetSetVector<Phase2TrackerCluster1D>::const_iterator sensor_2_cluster_collection = all_clusters.find(det_id + 2);
                     
                     // sensor_1_cic_0 and sensor_2_cic_0 form a single output daq channel.
-                    SensorHybrid Hybrid_1 (sensor_1_cluster_collection, sensor_2_cluster_collection, sensor_1_clusters_exist, sensor_2_clusters_exist, 0, trackerGeometry, eventId_);
+                    SensorHybrid Hybrid_1 (det_id, sensor_1_cluster_collection, sensor_2_cluster_collection, sensor_1_clusters_exist, sensor_2_clusters_exist, 0, trackerGeometry, eventId_);
 
                     // // sensor_1_cic_1 and sensor_2_cic_1 form a single output daq channel.
-                    SensorHybrid Hybrid_2 (sensor_1_cluster_collection, sensor_2_cluster_collection, sensor_1_clusters_exist, sensor_2_clusters_exist, 1, trackerGeometry, eventId_);
+                    SensorHybrid Hybrid_2 (det_id, sensor_1_cluster_collection, sensor_2_cluster_collection, sensor_1_clusters_exist, sensor_2_clusters_exist, 1, trackerGeometry, eventId_);
 
                     // sensor_2 is always isUpper == 1 for 2S.
                     // sensor_2 is always isLower == 0 for 2S.


### PR DESCRIPTION
#### PR description:

PR to fix issues when running the OT packer+unpacker sequence of type
"ERROR: Header for channel XX expects non-zero (XX) pixel clusters on a 2S module"

This was due to a return statement in case of empty cluster collections which prevented updating the sensor types.
The order has now been switched.

#### PR validation:

Running on 600 events of 
/RelValSingleEFlatPt2To100/CMSSW_15_0_0-PU_141X_mcRun4_realistic_v3_STD_Run4D110_PU-v3/GEN-SIM-DIGI-RAW
(D110 geometry)
and on 5K events of 
/RelValSingleEFlatPt2To100/CMSSW_14_0_0_pre2-133X_mcRun4_realistic_v1_STD_2026D98_noPU_RV229-v1/GEN-SIM-DIGI-RAW
(D98 geometry)
I see no occurrence of the LogError, nor any crash of the kind previously reported by the group working on porting the code to GPU (which I also observed before this fix).

I'll provide a similar PR for the current master branch which is "unpackers_16_0_0_pre1".