### PR TITLE
innertracker cabling map db writer

### DIFF
--- a/CondFormats/SiPhase2TrackerObjects/interface/TrackerDetToDTCELinkCablingMap.h
+++ b/CondFormats/SiPhase2TrackerObjects/interface/TrackerDetToDTCELinkCablingMap.h
@@ -21,6 +21,7 @@ Implementation:
 //
 //
 
+#include <map>
 #include <vector>
 #include <unordered_map>
 #include <cstdint>
@@ -88,7 +89,7 @@ public:
 private:
   std::unordered_multimap<uint32_t, DTCELinkId> cablingMapDetIdToDTCELinkId_;
   std::unordered_map<DTCELinkId, uint32_t> cablingMapDTCELinkIdToDetId_;
-  std::unordered_map<uint32_t, ModuleInfo> moduleInfoByDetId_;
+  std::map<uint32_t, ModuleInfo> moduleInfoByDetId_;
 
   COND_SERIALIZABLE;
 };

--- a/CondFormats/SiPhase2TrackerObjects/interface/TrackerDetToDTCELinkCablingMap.h
+++ b/CondFormats/SiPhase2TrackerObjects/interface/TrackerDetToDTCELinkCablingMap.h
@@ -31,7 +31,7 @@ Implementation:
 
 class TrackerDetToDTCELinkCablingMap {
 public:
-  /// Section ↔ uint8_t convention used by ModuleInfo::section.
+  /// Section <-> uint8_t convention used by ModuleInfo::section.
   enum class Section : uint8_t { Unknown = 0, TBPX = 1, TFPX = 2, TEPX = 3 };
 
   /// Per-module Aurora/cabling info (in addition to the per-elink mapping).

--- a/CondFormats/SiPhase2TrackerObjects/interface/TrackerDetToDTCELinkCablingMap.h
+++ b/CondFormats/SiPhase2TrackerObjects/interface/TrackerDetToDTCELinkCablingMap.h
@@ -16,6 +16,8 @@ Implementation:
 //
 // Original Author:  Luigi Calligaris, SPRACE, Sao Paulo, BR
 // Created        :  Wed, 27 Feb 2019 21:41:13 GMT
+// Updated :  Si Hyun Jeon, Boston University
+// Updated :  Thu, 21 May 2026
 //
 //
 
@@ -28,6 +30,22 @@ Implementation:
 
 class TrackerDetToDTCELinkCablingMap {
 public:
+  /// Section ↔ uint8_t convention used by ModuleInfo::section.
+  enum class Section : uint8_t { Unknown = 0, TBPX = 1, TFPX = 2, TEPX = 3 };
+
+  /// Per-module Aurora/cabling info (in addition to the per-elink mapping).
+  /// Default-constructed = "unknown / not filled in this DB version".
+  struct ModuleInfo {
+    uint8_t nChips  = 0;  // chips on the module
+    uint8_t nElinks = 0;  // elinks on the module
+    uint8_t section = 0;  // see Section enum
+    uint8_t layer   = 0;  // layer/disk indexes
+    uint8_t ring    = 0;  // ring indexes
+    uint8_t subtype = 0;  // subtype of the module
+
+    COND_SERIALIZABLE;
+  };
+
   TrackerDetToDTCELinkCablingMap();
   virtual ~TrackerDetToDTCELinkCablingMap();
 
@@ -59,12 +77,18 @@ public:
   /// Inserts in the cabling map a record corresponding to the connection of an eLink identified by the given DTCELinkId to a detector identified by the given raw DetId
   void insert(DTCELinkId const&, uint32_t const);
 
+  // Set / get per-module info (one entry per DetId)
+  void setModuleInfo(uint32_t detId, ModuleInfo const& info);
+  bool hasModuleInfo(uint32_t detId) const;
+  ModuleInfo const& getModuleInfo(uint32_t detId) const;
+
   /// Clears the map
   void clear();
 
 private:
   std::unordered_multimap<uint32_t, DTCELinkId> cablingMapDetIdToDTCELinkId_;
   std::unordered_map<DTCELinkId, uint32_t> cablingMapDTCELinkIdToDetId_;
+  std::unordered_map<uint32_t, ModuleInfo> moduleInfoByDetId_;
 
   COND_SERIALIZABLE;
 };

--- a/CondFormats/SiPhase2TrackerObjects/src/TrackerDetToDTCELinkCablingMap.cc
+++ b/CondFormats/SiPhase2TrackerObjects/src/TrackerDetToDTCELinkCablingMap.cc
@@ -87,7 +87,26 @@ void TrackerDetToDTCELinkCablingMap::insert(DTCELinkId const& dtcELinkId, uint32
   cablingMapDetIdToDTCELinkId_.insert(std::make_pair(uint32_t(detId), DTCELinkId(dtcELinkId)));
 }
 
+void TrackerDetToDTCELinkCablingMap::setModuleInfo(uint32_t detId, ModuleInfo const& info) {
+  moduleInfoByDetId_[detId] = info;
+}
+
+bool TrackerDetToDTCELinkCablingMap::hasModuleInfo(uint32_t detId) const {
+  return moduleInfoByDetId_.find(detId) != moduleInfoByDetId_.end();
+}
+
+TrackerDetToDTCELinkCablingMap::ModuleInfo const& TrackerDetToDTCELinkCablingMap::getModuleInfo(uint32_t detId) const {
+  auto it = moduleInfoByDetId_.find(detId);
+  if (it == moduleInfoByDetId_.end()) {
+    throw cms::Exception(
+        "TrackerDetToDTCELinkCablingMap has been asked to return ModuleInfo for a DetId not present in the map. ")
+        << " DetId = " << detId << std::endl;
+  }
+  return it->second;
+}
+
 void TrackerDetToDTCELinkCablingMap::clear() {
   cablingMapDTCELinkIdToDetId_.clear();
   cablingMapDetIdToDTCELinkId_.clear();
+  moduleInfoByDetId_.clear();
 }

--- a/CondFormats/SiPhase2TrackerObjects/src/classes.h
+++ b/CondFormats/SiPhase2TrackerObjects/src/classes.h
@@ -5,15 +5,21 @@
 namespace {
   struct dictionary {
     TrackerDetToDTCELinkCablingMap cabmap;
+    TrackerDetToDTCELinkCablingMap::ModuleInfo moduleInfo;
+    std::vector<std::vector<unsigned char>> chipToElinkTable;
 
     DTCELinkId dtcelinkid;
 
     std::unordered_map<unsigned int, DTCELinkId> unorderedMapUIntToDTC;
     std::unordered_multimap<DTCELinkId, unsigned int> unorderedMapDTCToUInt;
+    std::unordered_map<unsigned int, TrackerDetToDTCELinkCablingMap::ModuleInfo> unorderedMapUIntToModuleInfo;
 
     std::pair<unsigned int, DTCELinkId> unorderedMapUIntToDTC_data =
         std::make_pair<unsigned int, DTCELinkId>(0, DTCELinkId());
     std::pair<DTCELinkId, unsigned int> unorderedMapDTCToUInt_data =
         std::make_pair<DTCELinkId, unsigned int>(DTCELinkId(), 0);
+    std::pair<unsigned int, TrackerDetToDTCELinkCablingMap::ModuleInfo> unorderedMapUIntToModuleInfo_data =
+        std::make_pair<unsigned int, TrackerDetToDTCELinkCablingMap::ModuleInfo>(
+            0, TrackerDetToDTCELinkCablingMap::ModuleInfo());
   };
 }  // namespace

--- a/CondFormats/SiPhase2TrackerObjects/src/classes.h
+++ b/CondFormats/SiPhase2TrackerObjects/src/classes.h
@@ -6,7 +6,6 @@ namespace {
   struct dictionary {
     TrackerDetToDTCELinkCablingMap cabmap;
     TrackerDetToDTCELinkCablingMap::ModuleInfo moduleInfo;
-    std::vector<std::vector<unsigned char>> chipToElinkTable;
 
     DTCELinkId dtcelinkid;
 

--- a/CondFormats/SiPhase2TrackerObjects/src/classes.h
+++ b/CondFormats/SiPhase2TrackerObjects/src/classes.h
@@ -11,13 +11,13 @@ namespace {
 
     std::unordered_map<unsigned int, DTCELinkId> unorderedMapUIntToDTC;
     std::unordered_multimap<DTCELinkId, unsigned int> unorderedMapDTCToUInt;
-    std::unordered_map<unsigned int, TrackerDetToDTCELinkCablingMap::ModuleInfo> unorderedMapUIntToModuleInfo;
+    std::map<unsigned int, TrackerDetToDTCELinkCablingMap::ModuleInfo> mapUIntToModuleInfo;
 
     std::pair<unsigned int, DTCELinkId> unorderedMapUIntToDTC_data =
         std::make_pair<unsigned int, DTCELinkId>(0, DTCELinkId());
     std::pair<DTCELinkId, unsigned int> unorderedMapDTCToUInt_data =
         std::make_pair<DTCELinkId, unsigned int>(DTCELinkId(), 0);
-    std::pair<unsigned int, TrackerDetToDTCELinkCablingMap::ModuleInfo> unorderedMapUIntToModuleInfo_data =
+    std::pair<unsigned int, TrackerDetToDTCELinkCablingMap::ModuleInfo> mapUIntToModuleInfo_data =
         std::make_pair<unsigned int, TrackerDetToDTCELinkCablingMap::ModuleInfo>(
             0, TrackerDetToDTCELinkCablingMap::ModuleInfo());
   };

--- a/CondFormats/SiPhase2TrackerObjects/src/classes_def.xml
+++ b/CondFormats/SiPhase2TrackerObjects/src/classes_def.xml
@@ -1,7 +1,11 @@
 <lcgdict>
-	<class name="TrackerDetToDTCELinkCablingMap" class_version="0">
+	<class name="TrackerDetToDTCELinkCablingMap::ModuleInfo" class_version="1"/>
+	<class name="std::vector<std::vector<unsigned char>>"/>
+	<class name="std::unordered_map<unsigned int, TrackerDetToDTCELinkCablingMap::ModuleInfo>"/>
+	<class name="TrackerDetToDTCELinkCablingMap" class_version="1">
 		<field name="cablingMapDetIdToDTCELinkId_" mapping="blob" />
 		<field name="cablingMapDTCELinkIdToDetId_" mapping="blob" />
+		<field name="moduleInfoByDetId_"           mapping="blob" />
 	</class>
 	<class name="DTCELinkId" class_version="0">
 	</class>

--- a/CondFormats/SiPhase2TrackerObjects/src/classes_def.xml
+++ b/CondFormats/SiPhase2TrackerObjects/src/classes_def.xml
@@ -1,6 +1,5 @@
 <lcgdict>
-	<class name="TrackerDetToDTCELinkCablingMap::ModuleInfo" class_version="1"/>
-	<class name="std::vector<std::vector<unsigned char>>"/>
+	<class name="TrackerDetToDTCELinkCablingMap::ModuleInfo" class_version="0"/>
 	<class name="std::unordered_map<unsigned int, TrackerDetToDTCELinkCablingMap::ModuleInfo>"/>
 	<class name="TrackerDetToDTCELinkCablingMap" class_version="1">
 		<field name="cablingMapDetIdToDTCELinkId_" mapping="blob" />

--- a/CondFormats/SiPhase2TrackerObjects/src/classes_def.xml
+++ b/CondFormats/SiPhase2TrackerObjects/src/classes_def.xml
@@ -1,6 +1,6 @@
 <lcgdict>
 	<class name="TrackerDetToDTCELinkCablingMap::ModuleInfo" class_version="0"/>
-	<class name="std::unordered_map<unsigned int, TrackerDetToDTCELinkCablingMap::ModuleInfo>"/>
+	<class name="std::map<unsigned int, TrackerDetToDTCELinkCablingMap::ModuleInfo>"/>
 	<class name="TrackerDetToDTCELinkCablingMap" class_version="1">
 		<field name="cablingMapDetIdToDTCELinkId_" mapping="blob" />
 		<field name="cablingMapDTCELinkIdToDetId_" mapping="blob" />

--- a/CondTools/SiPhase2Tracker/plugins/DTCCablingMapProducer.cc
+++ b/CondTools/SiPhase2Tracker/plugins/DTCCablingMapProducer.cc
@@ -91,6 +91,14 @@ private:
   unsigned csvFormat_idtcid_;
   unsigned csvFormat_igbtlinkid_;
   unsigned csvFormat_ielinkid_;
+  // Optional per-module Aurora info columns; populated when read_innertracker_module_info_ is true.
+  bool     read_innertracker_module_info_;
+  unsigned csvFormat_inchips_;
+  unsigned csvFormat_inelinks_;
+  unsigned csvFormat_isection_;
+  unsigned csvFormat_ilayer_;
+  unsigned csvFormat_iring_;
+  unsigned csvFormat_isubtype_;
   cond::Time_t iovBeginTime_;
   std::unique_ptr<TrackerDetToDTCELinkCablingMap> pCablingMap_;
   std::string record_;
@@ -106,6 +114,15 @@ void DTCCablingMapProducer::fillDescriptions(edm::ConfigurationDescriptions& des
   desc.add<unsigned>("csvFormat_idtcid", 0);
   desc.add<unsigned>("csvFormat_igbtlinkid", 0);
   desc.add<unsigned>("csvFormat_ielinkid", 0);
+  // Below fields are only relelvant for IT cabling map
+  desc.add<bool>("read_innertracker_module_info", false);
+  desc.add<unsigned>("csvFormat_inchips",   0);
+  desc.add<unsigned>("csvFormat_inelinks",  0);
+  desc.add<unsigned>("csvFormat_isection",  0);
+  desc.add<unsigned>("csvFormat_ilayer",    0);
+  desc.add<unsigned>("csvFormat_iring",     0);
+  desc.add<unsigned>("csvFormat_isubtype",  0);
+  // Above fields are only relelvant for IT cabling map
   desc.add<long long unsigned int>("iovBeginTime", 1);
   desc.add<std::string>("record", "TrackerDTCCablingMapRcd");
   desc.add<std::vector<std::string>>("modulesToDTCCablingCSVFileNames", std::vector<std::string>());
@@ -119,6 +136,13 @@ DTCCablingMapProducer::DTCCablingMapProducer(const edm::ParameterSet& iConfig)
       csvFormat_idtcid_(iConfig.getParameter<unsigned>("csvFormat_idtcid")),
       csvFormat_igbtlinkid_(iConfig.getParameter<unsigned>("csvFormat_igbtlinkid")),
       csvFormat_ielinkid_(iConfig.getParameter<unsigned>("csvFormat_ielinkid")),
+      read_innertracker_module_info_(iConfig.getParameter<bool>("read_innertracker_module_info")),
+      csvFormat_inchips_(iConfig.getParameter<unsigned>("csvFormat_inchips")),
+      csvFormat_inelinks_(iConfig.getParameter<unsigned>("csvFormat_inelinks")),
+      csvFormat_isection_(iConfig.getParameter<unsigned>("csvFormat_isection")),
+      csvFormat_ilayer_(iConfig.getParameter<unsigned>("csvFormat_ilayer")),
+      csvFormat_iring_(iConfig.getParameter<unsigned>("csvFormat_iring")),
+      csvFormat_isubtype_(iConfig.getParameter<unsigned>("csvFormat_isubtype")),
       iovBeginTime_(iConfig.getParameter<long long unsigned int>("iovBeginTime")),
       pCablingMap_(std::make_unique<TrackerDetToDTCELinkCablingMap>()),
       record_(iConfig.getParameter<std::string>("record")) {
@@ -184,8 +208,10 @@ void DTCCablingMapProducer::LoadModulesToDTCCablingMapFromCSV(
         }
 
         if (csvColumn.size() == csvFormat_ncolumns_) {
-          // Skip the legend lines
-          if (0 == csvColumn[0].compare(std::string("Module_DetId/U"))) {
+          // Skip the legend lines.
+          // Heuristic: the legend's first column contains a "/" (e.g. "Module_DetId/U", "Sensor_DetId/i"); a real data row's first
+          // column is a numeric DetId.
+          if (csvColumn[0].find('/') != std::string::npos) {
             if (verbosity_ >= 1) {
               edm::LogInfo("CSVParser") << "-- skipping legend line" << endl;
             }
@@ -246,6 +272,23 @@ void DTCCablingMapProducer::LoadModulesToDTCCablingMapFromCSV(
           }
 
           pCablingMap_->insert(dtcELinkId, detIdRaw);
+
+          // Optional: per-module cabling info for innertracker
+          if (read_innertracker_module_info_) {
+            TrackerDetToDTCELinkCablingMap::ModuleInfo info;
+            info.nChips  = static_cast<uint8_t>(strtoul(csvColumn.at(csvFormat_inchips_ ).c_str(), nullptr, 10));
+            info.nElinks = static_cast<uint8_t>(strtoul(csvColumn.at(csvFormat_inelinks_).c_str(), nullptr, 10));
+            // Section is a short string in the CSV; map to enum value.
+            std::string const sec = csvColumn.at(csvFormat_isection_);
+            if      (sec == "TBPX") info.section = 1;
+            else if (sec == "TFPX") info.section = 2;
+            else if (sec == "TEPX") info.section = 3;
+            else                    info.section = 0;
+            info.layer   = static_cast<uint8_t>(strtoul(csvColumn.at(csvFormat_ilayer_  ).c_str(), nullptr, 10));
+            info.ring    = static_cast<uint8_t>(strtoul(csvColumn.at(csvFormat_iring_   ).c_str(), nullptr, 10));
+            info.subtype = static_cast<uint8_t>(strtoul(csvColumn.at(csvFormat_isubtype_).c_str(), nullptr, 10));
+            pCablingMap_->setModuleInfo(detIdRaw, info);
+          }
         } else {
           if (verbosity_ >= 3) {
             edm::LogInfo("CSVParser") << "Reading CSV file: Skipped a short line: \"" << csvLine << "\"" << endl;

--- a/CondTools/SiPhase2Tracker/plugins/DTCCablingMapTestReader.cc
+++ b/CondTools/SiPhase2Tracker/plugins/DTCCablingMapTestReader.cc
@@ -113,6 +113,36 @@ void DTCCablingMapTestReader::analyze(const edm::Event& iEvent, const edm::Event
 
     edm::LogInfo("DetToElinkCablingMapDump") << dump_ElinkToDet.str();
   }
+
+  {
+    // ModuleInfo dump (only the count + a sample, since dumping all modules would be excessive).
+    ostringstream dump_ModuleInfo;
+    std::vector<uint32_t> const knownDetIds = p_cablingMap->getKnownDetIds();
+    int n_with_info = 0;
+    int n_without_info = 0;
+    for (uint32_t detId : knownDetIds) {
+      if (p_cablingMap->hasModuleInfo(detId)) ++n_with_info;
+      else                                    ++n_without_info;
+    }
+    dump_ModuleInfo << "ModuleInfo dump: " << n_with_info << "/" << knownDetIds.size()
+                    << " modules have ModuleInfo populated (" << n_without_info << " without).\n";
+    // One sample per unique layout key (section, layer, ring) for compact diagnostic.
+    std::set<std::tuple<uint8_t, uint8_t, uint8_t>> seen_layouts;
+    for (uint32_t detId : knownDetIds) {
+      if (!p_cablingMap->hasModuleInfo(detId)) continue;
+      auto const& mi = p_cablingMap->getModuleInfo(detId);
+      auto key = std::make_tuple(mi.section, mi.layer, mi.ring);
+      if (!seen_layouts.insert(key).second) continue;  // already shown this layout
+      dump_ModuleInfo << "  detId=" << detId
+                      << "  nChips=" << unsigned(mi.nChips)
+                      << "  nElinks=" << unsigned(mi.nElinks)
+                      << "  section=" << unsigned(mi.section)
+                      << "  layer=" << unsigned(mi.layer)
+                      << "  ring=" << unsigned(mi.ring)
+                      << "  subtype=" << unsigned(mi.subtype) << "\n";
+    }
+    edm::LogInfo("DetToElinkCablingMapDump") << dump_ModuleInfo.str();
+  }
 }
 
 void DTCCablingMapTestReader::beginJob() {}

--- a/CondTools/SiPhase2Tracker/test/DTCCablingMapProducer_dump_IT.py
+++ b/CondTools/SiPhase2Tracker/test/DTCCablingMapProducer_dump_IT.py
@@ -1,0 +1,31 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("DTCCablingMapDump")
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(threshold = cms.untracked.string('INFO')),
+    cout = cms.untracked.PSet(enable = cms.untracked.bool(True),
+                              threshold = cms.untracked.string('INFO')),
+)
+
+process.load("CondCore.CondDB.CondDB_cfi")
+process.CondDB.connect = 'sqlite_file:OTandITDTCCablingMap.db'
+
+process.PoolDBESSource = cms.ESSource("PoolDBESSource",
+    process.CondDB,
+    DumpStat = cms.untracked.bool(True),
+    toGet = cms.VPSet(cms.PSet(
+        record = cms.string('TrackerDetToDTCELinkCablingMapRcd'),
+        tag    = cms.string("DTCCablingMapProducerUserRun"),
+    )),
+)
+
+process.source = cms.Source("EmptyIOVSource",
+    timetype   = cms.string('runnumber'),
+    firstValue = cms.uint64(1),
+    lastValue  = cms.uint64(1),
+    interval   = cms.uint64(1),
+)
+
+process.reader = cms.EDAnalyzer("DTCCablingMapTestReader")
+process.path = cms.Path(process.reader)

--- a/CondTools/SiPhase2Tracker/test/DTCCablingMapProducer_write_IT.py
+++ b/CondTools/SiPhase2Tracker/test/DTCCablingMapProducer_write_IT.py
@@ -39,7 +39,7 @@ process.otdtccablingmap_producer = cms.EDAnalyzer("DTCCablingMapProducer",
     ),
     csvFormat_ncolumns   = cms.uint32(20),
     csvFormat_idetid     = cms.uint32(1),    # Sensor_DetId (per-sensor key)
-    csvFormat_idtcid     = cms.uint32(17),   # DTC_CMSSW_Id
+    csvFormat_idtcid     = cms.uint32(16),   # DTC_Id
     csvFormat_igbtlinkid = cms.uint32(14),   # LpGBT_CMSSW_IdPerDTC
     csvFormat_ielinkid   = cms.uint32(0),    # not in CSV -> dummy-fill
     dummy_fill_mode      = cms.string("DUMMY_FILL_ELINK_ID"),  # gbt from CSV, elink auto

--- a/CondTools/SiPhase2Tracker/test/DTCCablingMapProducer_write_IT.py
+++ b/CondTools/SiPhase2Tracker/test/DTCCablingMapProducer_write_IT.py
@@ -1,0 +1,65 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("DTCCablingMapProducer")
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.load("CondCore.CondDB.CondDB_cfi")
+
+# Output sqlite db
+process.CondDB.connect = 'sqlite_file:OTandITDTCCablingMap.db'
+
+process.source = cms.Source("EmptyIOVSource",
+    timetype   = cms.string('runnumber'),
+    firstValue = cms.uint64(1),
+    lastValue  = cms.uint64(1),
+    interval   = cms.uint64(1),
+)
+
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+    process.CondDB,
+    timetype = cms.untracked.string('runnumber'),
+    toPut    = cms.VPSet(cms.PSet(
+        record = cms.string('TrackerDetToDTCELinkCablingMapRcd'),
+        tag    = cms.string('DTCCablingMapProducerUserRun'),
+    )),
+)
+
+# Standalone-CSV column layout (cabling.csv):
+#   0  Sensor_DetId/i              7  N_Chips_Per_Module/I
+#   1  Module_DetId/i              8  N_Channels_Per_Module/I
+#   2  Module_SubType/I            9  Is_LongBarrel/O
+#   3  Module_Section/C           10  Power_Chain/I
+#   4  Module_Layer/I             11  Power_Chain_Type/C
+#   5  Module_Ring/I              12  N_ELinks_Per_Module/I
+#   6  Module_phi_deg/D           13  LpGBT_Id/C
+#                                 14  LpGBT_CMSSW_IdPerDTC/U
+#                                 15  MFB/I
+#                                 16  DTC_Id/I
+#                                 17  DTC_CMSSW_Id/U
+#                                 18  IsPlusZEnd/O
+#                                 19  IsPlusXSide/O
+process.otdtccablingmap_producer = cms.EDAnalyzer("DTCCablingMapProducer",
+    record = cms.string('TrackerDetToDTCELinkCablingMapRcd'),
+    modulesToDTCCablingCSVFileNames = cms.vstring(
+        "CondTools/SiPhase2Tracker/test/it_cabling.csv",
+    ),
+    csvFormat_ncolumns   = cms.uint32(20),
+    csvFormat_idetid     = cms.uint32(1),    # Module_DetId
+    csvFormat_idtcid     = cms.uint32(17),   # DTC_CMSSW_Id
+    csvFormat_igbtlinkid = cms.uint32(14),   # LpGBT_CMSSW_IdPerDTC
+    csvFormat_ielinkid   = cms.uint32(0),    # not in CSV -> dummy-fill
+    dummy_fill_mode      = cms.string("DUMMY_FILL_ELINK_ID"),  # gbt from CSV, elink auto
+
+    # per-module info
+    read_innertracker_module_info = cms.bool(True),
+    csvFormat_inchips  = cms.uint32(7),
+    csvFormat_inelinks = cms.uint32(12),
+    csvFormat_isection = cms.uint32(3),
+    csvFormat_ilayer   = cms.uint32(4),
+    csvFormat_iring    = cms.uint32(5),
+    csvFormat_isubtype = cms.uint32(2),
+
+    verbosity = cms.int32(0),
+)
+
+process.path = cms.Path(process.otdtccablingmap_producer)

--- a/CondTools/SiPhase2Tracker/test/DTCCablingMapProducer_write_IT.py
+++ b/CondTools/SiPhase2Tracker/test/DTCCablingMapProducer_write_IT.py
@@ -24,8 +24,8 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
     )),
 )
 
-#   0  Sensor_DetId/i              7  N_Chips_Per_Module/I    13 LpGBT_Id/C
-#   1  Module_DetId/i              8  N_Channels_Per_Module/I 14 LpGBT_CMSSW_IdPerDTC/U
+#   0  Module_DetId/i              7  N_Chips_Per_Module/I    13 LpGBT_Id/C
+#   1  Sensor_DetId/i              8  N_Channels_Per_Module/I 14 LpGBT_CMSSW_IdPerDTC/U
 #   2  Module_SubType/I            9  Is_LongBarrel/O         15 MFB/I
 #   3  Module_Section/C           10  Power_Chain/I           16 DTC_Id/I
 #   4  Module_Layer/I             11  Power_Chain_Type/C      17 DTC_CMSSW_Id/U
@@ -38,7 +38,7 @@ process.otdtccablingmap_producer = cms.EDAnalyzer("DTCCablingMapProducer",
         "CondTools/SiPhase2Tracker/test/it_cabling.csv",
     ),
     csvFormat_ncolumns   = cms.uint32(20),
-    csvFormat_idetid     = cms.uint32(0),    # Sensor_DetId (per-sensor key)
+    csvFormat_idetid     = cms.uint32(1),    # Sensor_DetId (per-sensor key)
     csvFormat_idtcid     = cms.uint32(17),   # DTC_CMSSW_Id
     csvFormat_igbtlinkid = cms.uint32(14),   # LpGBT_CMSSW_IdPerDTC
     csvFormat_ielinkid   = cms.uint32(0),    # not in CSV -> dummy-fill

--- a/CondTools/SiPhase2Tracker/test/DTCCablingMapProducer_write_IT.py
+++ b/CondTools/SiPhase2Tracker/test/DTCCablingMapProducer_write_IT.py
@@ -24,34 +24,34 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
     )),
 )
 
-# InnerTrackerModulesToDTCs.csv column layout (19 columns):
-#   0  Module_DetId/i              6  N_Chips_Per_Module/I    12 LpGBT_Id/C
-#   1  Module_SubType/I            7  N_Channels_Per_Module/I 13 LpGBT_CMSSW_IdPerDTC/U
-#   2  Module_Section/C            8  Is_LongBarrel/O         14 MFB/I
-#   3  Module_Layer/I              9  Power_Chain/I           15 DTC_Id/I
-#   4  Module_Ring/I              10  Power_Chain_Type/C      16 DTC_CMSSW_Id/U
-#   5  Module_phi_deg/D           11  N_ELinks_Per_Module/I   17 IsPlusZEnd/O
-#                                                             18 IsPlusXSide/O
+#   0  Sensor_DetId/i              7  N_Chips_Per_Module/I    13 LpGBT_Id/C
+#   1  Module_DetId/i              8  N_Channels_Per_Module/I 14 LpGBT_CMSSW_IdPerDTC/U
+#   2  Module_SubType/I            9  Is_LongBarrel/O         15 MFB/I
+#   3  Module_Section/C           10  Power_Chain/I           16 DTC_Id/I
+#   4  Module_Layer/I             11  Power_Chain_Type/C      17 DTC_CMSSW_Id/U
+#   5  Module_Ring/I              12  N_ELinks_Per_Module/I   18 IsPlusZEnd/O
+#   6  Module_phi_deg/D                                       19 IsPlusXSide/O
+# Sensor_DetId is the key for inner trackers instead of Module_DetId
 process.otdtccablingmap_producer = cms.EDAnalyzer("DTCCablingMapProducer",
     record = cms.string('TrackerDetToDTCELinkCablingMapRcd'),
     modulesToDTCCablingCSVFileNames = cms.vstring(
-        "CondTools/SiPhase2Tracker/test/InnerTrackerModulesToDTCs.csv",
+        "CondTools/SiPhase2Tracker/test/it_cabling.csv",
     ),
-    csvFormat_ncolumns   = cms.uint32(19),
-    csvFormat_idetid     = cms.uint32(0),    # Module_DetId
-    csvFormat_idtcid     = cms.uint32(16),   # DTC_CMSSW_Id
-    csvFormat_igbtlinkid = cms.uint32(13),   # LpGBT_CMSSW_IdPerDTC
+    csvFormat_ncolumns   = cms.uint32(20),
+    csvFormat_idetid     = cms.uint32(0),    # Sensor_DetId (per-sensor key)
+    csvFormat_idtcid     = cms.uint32(17),   # DTC_CMSSW_Id
+    csvFormat_igbtlinkid = cms.uint32(14),   # LpGBT_CMSSW_IdPerDTC
     csvFormat_ielinkid   = cms.uint32(0),    # not in CSV -> dummy-fill
     dummy_fill_mode      = cms.string("DUMMY_FILL_ELINK_ID"),  # gbt from CSV, elink auto
 
     # per-module info
     read_innertracker_module_info = cms.bool(True),
-    csvFormat_inchips  = cms.uint32(6),
-    csvFormat_inelinks = cms.uint32(11),
-    csvFormat_isection = cms.uint32(2),
-    csvFormat_ilayer   = cms.uint32(3),
-    csvFormat_iring    = cms.uint32(4),
-    csvFormat_isubtype = cms.uint32(1),
+    csvFormat_inchips  = cms.uint32(7),
+    csvFormat_inelinks = cms.uint32(12),
+    csvFormat_isection = cms.uint32(3),
+    csvFormat_ilayer   = cms.uint32(4),
+    csvFormat_iring    = cms.uint32(5),
+    csvFormat_isubtype = cms.uint32(2),
 
     verbosity = cms.int32(0),
 )

--- a/CondTools/SiPhase2Tracker/test/DTCCablingMapProducer_write_IT.py
+++ b/CondTools/SiPhase2Tracker/test/DTCCablingMapProducer_write_IT.py
@@ -24,40 +24,34 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
     )),
 )
 
-# Standalone-CSV column layout (cabling.csv):
-#   0  Sensor_DetId/i              7  N_Chips_Per_Module/I
-#   1  Module_DetId/i              8  N_Channels_Per_Module/I
-#   2  Module_SubType/I            9  Is_LongBarrel/O
-#   3  Module_Section/C           10  Power_Chain/I
-#   4  Module_Layer/I             11  Power_Chain_Type/C
-#   5  Module_Ring/I              12  N_ELinks_Per_Module/I
-#   6  Module_phi_deg/D           13  LpGBT_Id/C
-#                                 14  LpGBT_CMSSW_IdPerDTC/U
-#                                 15  MFB/I
-#                                 16  DTC_Id/I
-#                                 17  DTC_CMSSW_Id/U
-#                                 18  IsPlusZEnd/O
-#                                 19  IsPlusXSide/O
+# InnerTrackerModulesToDTCs.csv column layout (19 columns):
+#   0  Module_DetId/i              6  N_Chips_Per_Module/I    12 LpGBT_Id/C
+#   1  Module_SubType/I            7  N_Channels_Per_Module/I 13 LpGBT_CMSSW_IdPerDTC/U
+#   2  Module_Section/C            8  Is_LongBarrel/O         14 MFB/I
+#   3  Module_Layer/I              9  Power_Chain/I           15 DTC_Id/I
+#   4  Module_Ring/I              10  Power_Chain_Type/C      16 DTC_CMSSW_Id/U
+#   5  Module_phi_deg/D           11  N_ELinks_Per_Module/I   17 IsPlusZEnd/O
+#                                                             18 IsPlusXSide/O
 process.otdtccablingmap_producer = cms.EDAnalyzer("DTCCablingMapProducer",
     record = cms.string('TrackerDetToDTCELinkCablingMapRcd'),
     modulesToDTCCablingCSVFileNames = cms.vstring(
-        "CondTools/SiPhase2Tracker/test/it_cabling.csv",
+        "CondTools/SiPhase2Tracker/test/InnerTrackerModulesToDTCs.csv",
     ),
-    csvFormat_ncolumns   = cms.uint32(20),
-    csvFormat_idetid     = cms.uint32(1),    # Module_DetId
-    csvFormat_idtcid     = cms.uint32(17),   # DTC_CMSSW_Id
-    csvFormat_igbtlinkid = cms.uint32(14),   # LpGBT_CMSSW_IdPerDTC
+    csvFormat_ncolumns   = cms.uint32(19),
+    csvFormat_idetid     = cms.uint32(0),    # Module_DetId
+    csvFormat_idtcid     = cms.uint32(16),   # DTC_CMSSW_Id
+    csvFormat_igbtlinkid = cms.uint32(13),   # LpGBT_CMSSW_IdPerDTC
     csvFormat_ielinkid   = cms.uint32(0),    # not in CSV -> dummy-fill
     dummy_fill_mode      = cms.string("DUMMY_FILL_ELINK_ID"),  # gbt from CSV, elink auto
 
     # per-module info
     read_innertracker_module_info = cms.bool(True),
-    csvFormat_inchips  = cms.uint32(7),
-    csvFormat_inelinks = cms.uint32(12),
-    csvFormat_isection = cms.uint32(3),
-    csvFormat_ilayer   = cms.uint32(4),
-    csvFormat_iring    = cms.uint32(5),
-    csvFormat_isubtype = cms.uint32(2),
+    csvFormat_inchips  = cms.uint32(6),
+    csvFormat_inelinks = cms.uint32(11),
+    csvFormat_isection = cms.uint32(2),
+    csvFormat_ilayer   = cms.uint32(3),
+    csvFormat_iring    = cms.uint32(4),
+    csvFormat_isubtype = cms.uint32(1),
 
     verbosity = cms.int32(0),
 )


### PR DESCRIPTION
This updated the scripts db dumper for inner tracker cabling maps

I've added an option `read_innertracker_module_info_` which hopefully does not change anything for the outer trackers

We did discuss of having a common map csv/db files for IT and OT, but since the column indexes are all out of sync, I just made a split config file so that IT does not have to trace the column numbers everytime to create the db file. At some point, we should revisit to merge these two again after discussing what fields are needed for both IT/OT and what are additionally needed for one of the two.

Most of the additional fields added for IT are due to the IT validation plots' needs


Updates in the PR
Adding more per module info from inner tracker cabling map csv file to dump to the db file
```
    uint8_t nChips  = 0;  // chips on the module
    uint8_t nElinks = 0;  // elinks on the module
    uint8_t section = 0;  // see Section enum
    uint8_t layer   = 0;  // layer/disk indexes
    uint8_t ring    = 0;  // ring indexes
    uint8_t subtype = 0;  // subtype of the module
```