### PR TITLE
Include the Slink-header in the packer/unpacker chain

### DIFF
--- a/EventFilter/Phase2TrackerRawToDigi/interface/Phase2DAQFormatSpecification.h
+++ b/EventFilter/Phase2TrackerRawToDigi/interface/Phase2DAQFormatSpecification.h
@@ -49,6 +49,9 @@ namespace Phase2DAQFormatSpecification {
   static const int SS_CLUSTER_WORD_MASK = 0x3FFF;
   static const int PX_CLUSTER_WORD_MASK = 0x1FFFF;
 
+  static const int SLINK_BOE = 0x55;
+  static const int SLINK_HEADER_BYTES = 16;
+
   typedef std::bitset<32> Word32Bits;
 
 };  // namespace Phase2DAQFormatSpecification

--- a/EventFilter/Phase2TrackerRawToDigi/plugins/ClusterToRawProducer.cc
+++ b/EventFilter/Phase2TrackerRawToDigi/plugins/ClusterToRawProducer.cc
@@ -87,7 +87,12 @@ void ClusterToRawProducer::produce(edm::Event& iEvent, const edm::EventSetup& iS
       std::vector<Word32Bits> daq_packet;
       std::vector<Word32Bits> offset_map(CICs_PER_SLINK / 2, Word32Bits(0));
 
-      daq_packet.reserve(4);
+      daq_packet.reserve(8);
+      for (int i = 0; i < 3; ++i) {
+        daq_packet.push_back(Word32Bits(0));
+      }
+      daq_packet.push_back(Word32Bits(SLINK_BOE));
+
 for (int i = 0; i < 4; ++i) {
         daq_packet.push_back(Word32Bits(DTC_DAQ_HEADER));
       }

--- a/EventFilter/Phase2TrackerRawToDigi/plugins/RawToClusterProducer.cc
+++ b/EventFilter/Phase2TrackerRawToDigi/plugins/RawToClusterProducer.cc
@@ -134,9 +134,15 @@ void RawToClusterProducer::produce(edm::Event& iEvent, const edm::EventSetup& iS
       if (fedData.size() > 0) {
         const unsigned char* dataPtr = fedData.data();
 
+        // look for the BOE magic word in the S-link header
+        bool isBOE = (static_cast<uint8_t>(dataPtr[SLINK_HEADER_BYTES-1]) == SLINK_BOE) ? true : false;
+        if (!isBOE)
+            edm::LogWarning("RawToClusterProducer") 
+                << "WARNING: Couldn't find BOE in the S-Link Header " ;
+
         // read the header
         std::vector<uint32_t> headerWords;
-        for (size_t i = 0; i < HEADER_N_LINES * N_BYTES_PER_WORD;
+        for (size_t i = SLINK_HEADER_BYTES; i < HEADER_N_LINES * N_BYTES_PER_WORD + SLINK_HEADER_BYTES;
              i += N_BYTES_PER_WORD)  // Read 4 bytes (32 bits) at a time
         {
           // Extract 4 bytes (32 bits) and pack them into a uint32_t word
@@ -147,7 +153,7 @@ void RawToClusterProducer::produce(edm::Event& iEvent, const edm::EventSetup& iS
         // read the offsets: each 32 bit word contains two offset words of 16 bit each
         std::vector<uint32_t> offsetWords;
         size_t nOffsetsLines = OFFSET_BITS * CICs_PER_SLINK / N_BITS_PER_WORD;
-        size_t initByte = HEADER_N_LINES * N_BYTES_PER_WORD;
+        size_t initByte = SLINK_HEADER_BYTES + HEADER_N_LINES * N_BYTES_PER_WORD;
         size_t endByte =
             (nOffsetsLines - 1) * N_BYTES_PER_WORD + initByte;  // -1 because we only need the starting i of the line
 
@@ -195,7 +201,7 @@ void RawToClusterProducer::produce(edm::Event& iEvent, const edm::EventSetup& iS
           }
 
           // find the channel offset
-          int initial_offset = (HEADER_N_LINES + MODULES_PER_SLINK) * N_BYTES_PER_WORD;
+          int initial_offset = initByte + nOffsetsLines * N_BYTES_PER_WORD;
           int idx = initial_offset + theOffsets.getOffsetForChannel(iChannel) * N_BYTES_PER_WORD;
 
           // get the channel header and unpack it


### PR DESCRIPTION
#### PR description:

Since the [S-Link header](https://edms.cern.ch/ui/file/2502737/2/cms_phase2_slinkrocket.pdf) (128b) will be included in the FedRawDataCollection, the unpacker has been modified to correctly process those lines.
In order to be able to run the packer-unpacker chain after this change, a "fake" S-Link header (only containing the BOE field and then padded to 128b) is also included in the FedRawDataCollection produced by the packer code.

#### PR validation:

The new code has been validated against the previous version, and plots are available [here](https://fiorendi.web.cern.ch/BESOffline/unpacker_SlinkH_validation/)