### PR TITLE
update to rawdatabuffer & correct the slink module mapping

### DIFF
--- a/EventFilter/Phase2PixelRawToDigi/plugins/BitStreamToRawProducer.cc
+++ b/EventFilter/Phase2PixelRawToDigi/plugins/BitStreamToRawProducer.cc
@@ -1,6 +1,7 @@
-// EDProducer that takes bitstream to FEDRawData (Packer)
+// EDProducer that takes bitstream to RawDataBuffer (Packer)
 
 #include <memory>
+#include <new>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/one/EDProducer.h"
@@ -15,8 +16,8 @@
 
 #include "DataFormats/Phase2TrackerDigi/interface/Phase2ITChipBitStream.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
-#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
-#include "DataFormats/FEDRawData/interface/FEDRawData.h"
+#include "DataFormats/FEDRawData/interface/RawDataBuffer.h"
+#include "DataFormats/FEDRawData/interface/SLinkRocketHeaders.h"
 #include "EventFilter/Phase2PixelRawToDigi/interface/Phase2DAQFormatSpecification.h"
 #include "EventFilter/Phase2PixelRawToDigi/interface/SLinkModuleMap.h"
 
@@ -48,7 +49,7 @@ BitStreamToRawProducer::BitStreamToRawProducer(const edm::ParameterSet& iConfig)
           esConsumes<TrackerDetToDTCELinkCablingMap, TrackerDetToDTCELinkCablingMapRcd, edm::Transition::BeginRun>()),
       ITChipBitStreamToken_(consumes<edm::DetSetVector<Phase2ITChipBitStream>>(
           iConfig.getParameter<edm::InputTag>("Phase2ITChipBitStream"))) {
-  produces<FEDRawDataCollection>();
+  produces<RawDataBuffer>();
 }
 
 void BitStreamToRawProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -65,7 +66,6 @@ void BitStreamToRawProducer::produce(edm::Event& iEvent, const edm::EventSetup& 
   using namespace edm;
   using namespace std;
 
-  auto fedRawDataCollection = std::make_unique<FEDRawDataCollection>();
   edm::Handle<edm::DetSetVector<Phase2ITChipBitStream>> handle;
   iEvent.getByToken(ITChipBitStreamToken_, handle);
 
@@ -73,15 +73,35 @@ void BitStreamToRawProducer::produce(edm::Event& iEvent, const edm::EventSetup& 
     throw cms::Exception("BitStreamToRawProducer") << "Invalid BitStream handle";
   }
 
-  // Loop over slinks to fill in the bitstreams
-  for (const auto& entry : slinkMap_->fedIdToDetIds()) {
-    int fedId = entry.first;
-    const std::vector<uint32_t>& detIds = entry.second;
+  // Per-fragment scratch: cached offset/data bit-vectors + total bytes including
+  // SLinkRocket header/trailer + IT header/trailer placeholders.
+  struct FedFrame {
+    int fedId;
+    std::vector<bool> offsetBlock;  // already padded to 128-bit
+    std::vector<bool> dataBlock;    // already padded to 128-bit
+    unsigned int totalSize;         // bytes
+  };
+  std::vector<FedFrame> frames;
+  frames.reserve(slinkMap_->fedIdToDetIds().size());
 
-    // Block 2: per-module offsets.
-    // Block 3: per-module sequence of (chip header word, chip bitstream, 32-bit pad) repeated for CHIPS_PER_MODULE chips
-    std::vector<bool> offsetBlock;
-    std::vector<bool> dataBlock;
+  // Each fragment carries:
+  //   SLinkRocket header (16 B)
+  // + IT header placeholder (16 B = HEADER_TRAILER_LINES words)
+  // + offset table (128-bit padded)
+  // + data block (128-bit padded)
+  // + IT trailer placeholder (16 B)
+  // + SLinkRocket trailer (16 B)
+  const unsigned int SLINK_HDR_BYTES = sizeof(SLinkRocketHeader_v3);
+  const unsigned int SLINK_TRL_BYTES = sizeof(SLinkRocketTrailer_v3);
+  const unsigned int IT_HDR_BYTES    = HEADER_TRAILER_LINES * BYTES_PER_WORD;
+  const unsigned int IT_TRL_BYTES    = HEADER_TRAILER_LINES * BYTES_PER_WORD;
+
+  // Build bit blocks per FED and compute totalSize=totalRawDataBuffer.
+  uint32_t totalRawDataBuffer = 0;
+  for (const auto& entry : slinkMap_->fedIdToDetIds()) {
+    FedFrame f;
+    f.fedId = entry.first;
+    const std::vector<uint32_t>& detIds = entry.second;
 
     for (uint32_t detId : detIds) {
       auto foundDetId = handle->find(detId);
@@ -90,16 +110,19 @@ void BitStreamToRawProducer::produce(edm::Event& iEvent, const edm::EventSetup& 
       }
       const edm::DetSet<Phase2ITChipBitStream>& detSet = *foundDetId;
 
+      // Block 2: per-module offsets.
       // Module-level offset = dataBlock position for module in 32-bit words.
       // FIXME For the first module the value is always 0, is it necessary?
-      uint32_t moduleOffset = dataBlock.size() / BITS_PER_WORD;
-      addWordToBitVector(offsetBlock, moduleOffset);
+      uint32_t moduleOffset = f.dataBlock.size() / BITS_PER_WORD;
+      addWordToBitVector(f.offsetBlock, moduleOffset);
 
+      // Block 3: per-module sequence of (chip header word, chip bitstream, 32-bit pad)
+      // repeated for CHIPS_PER_MODULE chips.
       for (auto const& chip : detSet) {
         std::vector<bool> chipBitStream = chip.get_bitstream();
         unsigned int bitstreamSize = chipBitStream.size();
         unsigned int sizeWords = (bitstreamSize + BITS_PER_WORD - 1) / BITS_PER_WORD;
-        unsigned int endBit = bitstreamSize % BITS_PER_WORD;  // 0 means no last word : full or empty
+        unsigned int endBit = bitstreamSize % BITS_PER_WORD;
 
         // Per-chip header word:
         //   bits 31..28 : magic = 0xE
@@ -109,71 +132,97 @@ void BitStreamToRawProducer::produce(edm::Event& iEvent, const edm::EventSetup& 
         //   bits 15..0  : chip bitstream size in 32-bit words, NOT PER MODULE
         uint32_t chipHeader = ((CHIP_HEADER_MAGIC & 0xF) << 28) | ((0u & 0xF) << 24) | ((0u & 0x7) << 21) |
                               ((endBit & 0x1F) << 16) | (sizeWords & 0xFFFF);
-        addWordToBitVector(dataBlock, chipHeader);
-
-        dataBlock.insert(dataBlock.end(), chipBitStream.begin(), chipBitStream.end());
+        addWordToBitVector(f.dataBlock, chipHeader);
+        f.dataBlock.insert(f.dataBlock.end(), chipBitStream.begin(), chipBitStream.end());
 
         // Pad chip bitstream to 32-bit boundary
         unsigned int chipPadBits = (endBit > 0) ? (BITS_PER_WORD - endBit) : 0;
         if (chipPadBits > 0) {
-          dataBlock.insert(dataBlock.end(), chipPadBits, false);
+          f.dataBlock.insert(f.dataBlock.end(), chipPadBits, false);
         }
       }
 
       // Pad module to 128-bit boundary at module end
-      padToChunkBoundary(dataBlock);
+      padToChunkBoundary(f.dataBlock);
     }
 
     // Pad offset block to 128-bit boundary
-    padToChunkBoundary(offsetBlock);
+    padToChunkBoundary(f.offsetBlock);
 
-    // Calculate sizes in bytes
-    unsigned int headerSize = HEADER_TRAILER_LINES * BYTES_PER_WORD;
-    unsigned int offsetSize = offsetBlock.size() / BITS_PER_WORD * BYTES_PER_WORD;
-    unsigned int dataSize = dataBlock.size() / BITS_PER_WORD * BYTES_PER_WORD;
-    unsigned int trailerSize = HEADER_TRAILER_LINES * BYTES_PER_WORD;
-    unsigned int totalSize = headerSize + offsetSize + dataSize + trailerSize;
+    unsigned int offsetSize = f.offsetBlock.size() / BITS_PER_WORD * BYTES_PER_WORD;
+    unsigned int dataSize   = f.dataBlock.size()   / BITS_PER_WORD * BYTES_PER_WORD;
+    f.totalSize = SLINK_HDR_BYTES + IT_HDR_BYTES + offsetSize + dataSize + IT_TRL_BYTES + SLINK_TRL_BYTES;
+    totalRawDataBuffer += f.totalSize;
+    frames.push_back(std::move(f));
+  }
 
-    FEDRawData& slinkData = fedRawDataCollection->FEDData(fedId);
-    slinkData.resize(totalSize);
-    unsigned char* buffer = slinkData.data();
+  // Allocate one RawDataBuffer big enough to hold every fragment,
+  // then fill each one in-place via addSource(srcId, nullptr, totalSize).
+  auto raw = std::make_unique<RawDataBuffer>(totalRawDataBuffer);
 
-    // Header (4 lines of 0xFFFFFFFF) FIXME Dummy given for now
+  const auto& aux = iEvent.eventAuxiliary();
+  const uint64_t eventId = aux.event();
+  const uint32_t orbitId = aux.orbitNumber();
+  const uint16_t bxId    = static_cast<uint16_t>(aux.bunchCrossing());
+
+  for (auto& f : frames) {
+    unsigned char* buffer = raw->addSource(f.fedId, nullptr, f.totalSize);
+
+    // SLinkRocket header (16 B) at the very start.
+    const uint16_t l1a_types  = 1;
+    const uint8_t  l1a_phys   = 0;
+    const uint8_t  emu_status = 2;  // DTH emulator
+    new ((void*)buffer)
+        SLinkRocketHeader_v3(static_cast<uint32_t>(f.fedId), l1a_types, l1a_phys, emu_status, eventId);
+
+    // Word index within the fragment (4-byte words) after the SLinkRocket header.
+    unsigned int wordIdx = SLINK_HDR_BYTES / BYTES_PER_WORD;  // = 4
+
+    // IT header placeholder (4 lines of 0xFFFFFFFF) FIXME Dummy given for now
     for (int i = 0; i < HEADER_TRAILER_LINES; i++) {
-      addWordToBuffer(buffer, i, HEADER_TRAILER_PATTERN);
+      addWordToBuffer(buffer, wordIdx++, HEADER_TRAILER_PATTERN);
     }
 
     // Offset block
-    unsigned int offsetWords = offsetBlock.size() / BITS_PER_WORD;
+    unsigned int offsetWords = f.offsetBlock.size() / BITS_PER_WORD;
     for (unsigned int i = 0; i < offsetWords; i++) {
       uint32_t word = 0;
       for (int bit = 0; bit < BITS_PER_WORD; bit++) {
-        if (offsetBlock[i * BITS_PER_WORD + bit]) {
+        if (f.offsetBlock[i * BITS_PER_WORD + bit]) {
           word |= (1 << (31 - bit));
         }
       }
-      addWordToBuffer(buffer, HEADER_TRAILER_LINES + i, word);
+      addWordToBuffer(buffer, wordIdx++, word);
     }
 
     // Data block
-    unsigned int dataWords = dataBlock.size() / BITS_PER_WORD;
+    unsigned int dataWords = f.dataBlock.size() / BITS_PER_WORD;
     for (unsigned int i = 0; i < dataWords; i++) {
       uint32_t word = 0;
       for (int bit = 0; bit < BITS_PER_WORD; bit++) {
-        if (dataBlock[i * BITS_PER_WORD + bit]) {
+        if (f.dataBlock[i * BITS_PER_WORD + bit]) {
           word |= (1 << (31 - bit));
         }
       }
-      addWordToBuffer(buffer, HEADER_TRAILER_LINES + offsetWords + i, word);
+      addWordToBuffer(buffer, wordIdx++, word);
     }
 
-    // Trailer (4 lines of 0xFFFFFFFF) FIXME dummy given for now
+    // IT trailer placeholder (4 lines of 0xFFFFFFFF) FIXME dummy given for now
     for (int i = 0; i < HEADER_TRAILER_LINES; i++) {
-      addWordToBuffer(buffer, HEADER_TRAILER_LINES + offsetWords + dataWords + i, HEADER_TRAILER_PATTERN);
+      addWordToBuffer(buffer, wordIdx++, HEADER_TRAILER_PATTERN);
     }
+
+    // SLinkRocket trailer (16 B) at the very end. event_length_wcount is the
+    // fragment size in 16-byte SLinkRocket words.
+    const uint16_t status  = 0;
+    const uint16_t crc     = 0;
+    const uint16_t daq_crc = 0;
+    const uint32_t evtLenWc = f.totalSize >> SLR_WORD_NUM_BYTES_SHIFT;
+    new ((void*)(buffer + f.totalSize - SLINK_TRL_BYTES))
+        SLinkRocketTrailer_v3(status, crc, orbitId, bxId, evtLenWc, daq_crc);
   }
 
-  iEvent.put(std::move(fedRawDataCollection));
+  iEvent.put(std::move(raw));
 }
 
 void BitStreamToRawProducer::addWordToBuffer(unsigned char* buffer, size_t position, uint32_t word) {

--- a/EventFilter/Phase2PixelRawToDigi/plugins/RawToBitStreamProducer.cc
+++ b/EventFilter/Phase2PixelRawToDigi/plugins/RawToBitStreamProducer.cc
@@ -1,4 +1,4 @@
-// EDProducer that takes FEDRawData and produces ITChipBitStream
+// EDProducer that takes RawDataBuffer and produces ITChipBitStream
 // Very first step of unpacker
 
 #include <memory>
@@ -20,7 +20,8 @@
 
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 
-#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
+#include "DataFormats/FEDRawData/interface/RawDataBuffer.h"
+#include "DataFormats/FEDRawData/interface/SLinkRocketHeaders.h"
 #include "DataFormats/Phase2TrackerDigi/interface/Phase2ITChipBitStream.h"
 #include "EventFilter/Phase2PixelRawToDigi/interface/Phase2DAQFormatSpecification.h"
 #include "EventFilter/Phase2PixelRawToDigi/interface/SLinkModuleMap.h"
@@ -55,7 +56,7 @@ private:
                   int fedId,
                   edmNew::DetSetVector<Phase2ITChipBitStream>& output);
 
-  const edm::EDGetTokenT<FEDRawDataCollection> fedRawDataToken_;
+  const edm::EDGetTokenT<RawDataBuffer> fedRawDataToken_;
   const edm::ESGetToken<TrackerDetToDTCELinkCablingMap, TrackerDetToDTCELinkCablingMapRcd> cablingMapToken_;
 
   std::unique_ptr<SLinkModuleMap> slinkMap_;
@@ -64,7 +65,7 @@ private:
 };
 
 RawToBitStreamProducer::RawToBitStreamProducer(const edm::ParameterSet& iConfig)
-    : fedRawDataToken_(consumes<FEDRawDataCollection>(iConfig.getParameter<edm::InputTag>("fedRawDataCollection"))),
+    : fedRawDataToken_(consumes<RawDataBuffer>(iConfig.getParameter<edm::InputTag>("fedRawDataCollection"))),
       cablingMapToken_(
           esConsumes<TrackerDetToDTCELinkCablingMap, TrackerDetToDTCELinkCablingMapRcd, edm::Transition::BeginRun>()),
       debug_(iConfig.getUntrackedParameter<bool>("debug", false)) {
@@ -84,17 +85,48 @@ void RawToBitStreamProducer::beginRun(const edm::Run& iRun, const edm::EventSetu
 
 void RawToBitStreamProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   auto output = std::make_unique<edmNew::DetSetVector<Phase2ITChipBitStream>>();
-  edm::Handle<FEDRawDataCollection> fedRawDataCollection;
-  iEvent.getByToken(fedRawDataToken_, fedRawDataCollection);
-  if (!fedRawDataCollection.isValid()) {
-    throw cms::Exception("RawToBitStreamProducer") << "Invalid FEDRawDataCollection";
+  edm::Handle<RawDataBuffer> rawBuf;
+  iEvent.getByToken(fedRawDataToken_, rawBuf);
+  if (!rawBuf.isValid()) {
+    throw cms::Exception("RawToBitStreamProducer") << "Invalid RawDataBuffer";
   }
+
+  const unsigned int SLINK_HDR_BYTES = sizeof(SLinkRocketHeader_v3);
+  const unsigned int SLINK_TRL_BYTES = sizeof(SLinkRocketTrailer_v3);
+  const unsigned int WRAPPER_WORDS   = (SLINK_HDR_BYTES + SLINK_TRL_BYTES) / BYTES_PER_WORD;
 
   for (const auto& entry : slinkMap_->fedIdToDetIds()) {
     int fedId = entry.first;
-    const FEDRawData& fedData = fedRawDataCollection->FEDData(fedId);
-    const unsigned char* dataPtr = fedData.data();
-    int fedSizeInWords = fedData.size() / 4;
+    auto frag = rawBuf->fragmentData(static_cast<uint32_t>(fedId));
+    if (!frag.isValid()) {
+      throw cms::Exception("RawToBitStreamProducer")
+          << "Missing RawDataBuffer fragment for fed " << fedId
+          << ": cabling map lists this FED but the buffer has no source for it.";
+    }
+    auto span = frag.data();
+    const unsigned char* fragPtr = span.data();
+    uint32_t fragSize            = span.size();
+
+    // Validate SLinkRocket wrapper.
+    auto const* sh = reinterpret_cast<const SLinkRocketHeader_v3*>(fragPtr);
+    auto const* st = reinterpret_cast<const SLinkRocketTrailer_v3*>(fragPtr + fragSize - SLINK_TRL_BYTES);
+    if (!sh->verifyMarker()) {
+      throw cms::Exception("RawToBitStreamProducer")
+          << "Invalid SLinkRocket BOE for fed " << fedId;
+    }
+    if (!st->verifyMarker()) {
+      throw cms::Exception("RawToBitStreamProducer")
+          << "Invalid SLinkRocket EOE for fed " << fedId;
+    }
+    if (st->eventLenBytes() != fragSize) {
+      throw cms::Exception("RawToBitStreamProducer")
+          << "SLinkRocket trailer length mismatch for fed " << fedId
+          << ": trailer says " << st->eventLenBytes() << ", actual " << fragSize;
+    }
+
+    // Hand the IT-specific body (IT header + offsets + data + IT trailer)
+    const unsigned char* dataPtr = fragPtr + SLINK_HDR_BYTES;
+    int fedSizeInWords = static_cast<int>(fragSize / BYTES_PER_WORD) - WRAPPER_WORDS;
     processFED(dataPtr, fedSizeInWords, fedId, *output);
   }
   iEvent.put(std::move(output));

--- a/EventFilter/Phase2PixelRawToDigi/src/SLinkModuleMap.cc
+++ b/EventFilter/Phase2PixelRawToDigi/src/SLinkModuleMap.cc
@@ -17,22 +17,24 @@ SLinkModuleMap::SLinkModuleMap(const TrackerDetToDTCELinkCablingMap& cablingMap)
     auto detIds = cablingMap.getAllDetIdsForDTCId(dtcId);
     std::sort(detIds.begin(), detIds.end());
 
+    // Round-robin distribution of a DTC's modules across its S-Links.
+    // Module i (in sorted detId order) goes to S-Link (i % SLINKS_PER_DTC).
     int total = static_cast<int>(detIds.size());
+
+    // Pre-reserve per FED vectors.
     int base = total / SLINKS_PER_DTC;
     int remainder = total % SLINKS_PER_DTC;
-
-    int moduleIndex = 0;
     for (int slinkId = 0; slinkId < SLINKS_PER_DTC; ++slinkId) {
-      int modulesForThisSlink = base + ((slinkId < remainder) ? 1 : 0);
-
       int fedId = static_cast<int>(dtcIndex) * SLINKS_PER_DTC + slinkId;
-      auto& vec = fedIdToDetIds_[fedId];
-      vec.reserve(modulesForThisSlink);
-      for (int i = 0; i < modulesForThisSlink; ++i) {
-        uint32_t detId = detIds[moduleIndex++];
-        vec.push_back(detId);
-        detIdToFedId_[detId] = fedId;
-      }
+      fedIdToDetIds_[fedId].reserve(base + ((slinkId < remainder) ? 1 : 0));
+    }
+
+    for (int i = 0; i < total; ++i) {
+      int slinkId = i % SLINKS_PER_DTC;
+      int fedId = static_cast<int>(dtcIndex) * SLINKS_PER_DTC + slinkId;
+      uint32_t detId = detIds[i];
+      fedIdToDetIds_[fedId].push_back(detId);
+      detIdToFedId_[detId] = fedId;
     }
   }
 }

--- a/EventFilter/Phase2PixelRawToDigi/test/PixelDigiToRawProducer_cfg.py
+++ b/EventFilter/Phase2PixelRawToDigi/test/PixelDigiToRawProducer_cfg.py
@@ -89,7 +89,7 @@ process.FEVTDEBUGoutput = cms.OutputModule("PoolOutputModule",
     fileName = cms.untracked.string('output_file.root'),
     outputCommands = cms.untracked.vstring(
         'drop *',
-        #'keep FEDRawDataCollection_*_*_*',
+        #'keep RawDataBuffer_*_*_*',
         #'keep Phase2IT*_*_*_*',  # Save intermediate Phase2ITChipBitStream
         #'keep PixelDigi*_*_*_*'
     )


### PR DESCRIPTION
#### PR description:

- Updating `FEDRawData` to `RawDataBuffer` for IT packer & unpacker
- Minor fix in `SLinkModuleMap.cc` : Previously roundrobin method was not correctly implemented

#### PR validation:

<img width="407" height="208" alt="image" src="https://github.com/user-attachments/assets/f3ffb315-8d23-44ca-b5a4-8a7620495992" />
